### PR TITLE
Adding del_user for testing purposes

### DIFF
--- a/werkzeug/contrib/authdigest.py
+++ b/werkzeug/contrib/authdigest.py
@@ -76,6 +76,8 @@ class RealmDigestDB(object):
         r = self.alg.hashPassword(user, self.realm, password)
         self.db[user] = r
         return r
+    def del_user(self, user):
+        del self.db[user]
 
     def __contains__(self, user):
         return user in self.db


### PR DESCRIPTION
In our tests cases we wanted to add/remove users from the user base through out the tests, but a method for removing users was  missing. This little patch just adds such method that removes the entry from the internal dictionary.
