### PR TITLE
Support for absolute URLs in HTTP requests

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -61,8 +61,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return 'Werkzeug/' + werkzeug.__version__
 
     def make_environ(self):
-        if self.path.startswith('http://'):
-            # we have received an absolute URL, the domain should be discarded
+        if self.path.startswith('http'):
+            # we have received an absolute URL, the domain should be discarded (http or https)
             segments = self.path.split('/')[3:]
             segments.insert(0,"")  # starts with slash
             self.path = "/".join(segments)

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -61,6 +61,11 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return 'Werkzeug/' + werkzeug.__version__
 
     def make_environ(self):
+        if self.path.startswith('http://'):
+            # we have received an absolute URL, the domain should be discarded
+            segments = self.path.split('/')[3:]
+            segments.insert(0,"")  # starts with slash
+            self.path = "/".join(segments)
         if '?' in self.path:
             path_info, query = self.path.split('?', 1)
         else:


### PR DESCRIPTION
The requests with absolute URLs were not supported.
A request such as

GET http://localhost:5100/healthcheck HTTP/1.1

makes PATH_INFO receive http://localhost:5100/healthcheck instead of just /healthcheck.
I believe this can be fixed in serving.py by testing if path starts with http:// and discarding the domain part before setting PATH_INFO.
